### PR TITLE
WP Compatibility Fixes

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -780,7 +780,7 @@ class WP_Object_Cache {
 	 * @param   null $persistent_id      To create an instance that persists between requests, use persistent_id to specify a unique ID for the instance.
 	 */
 	public function __construct() {
-		include 'predis/autoload.php';
+		require_once 'predis/autoload.php';
 
 		$this->redis = new Predis\Client( '' );
 


### PR DESCRIPTION
I added the `add_global_groups()` and `add_non_persistent_groups()` methods to the `WP_Object_Cache` class because their absence triggered fatal errors in WP 3.6-RC1. Adding the two functions was easy enough because the array that each manipulates already exists and is used within the object cache class as Core intended. Fixing the fatal error was simply a matter of defining the functions and ensuring the proper variables are modified by these new methods.

Also, rather than blindly include the Predis library, I swapped the `include` for a `require_once` to accomodate situations where the object cache class may be instantiated more than once. Batcache does this, for example.
